### PR TITLE
Change the name of the database that mongoseed.bat seeds

### DIFF
--- a/database/mongoseed.bat
+++ b/database/mongoseed.bat
@@ -1,8 +1,7 @@
 @ECHO OFF
-echo Dropping DB dev
-mongo dev --eval "db.dropDatabase()"
+echo Dropping DB team4IterationDev
+mongo team4IterationDev --eval "db.dropDatabase()"
 for %%f in (seed\*.json) do (
-  echo Seeding %%~nf from %%f in DB dev
-  mongoimport --db=dev --collection=%%~nf --file=%%f --jsonArray
+  echo Seeding %%~nf from %%f in DB team4IterationDev
+  mongoimport --db=team4IterationDev --collection=%%~nf --file=%%f --jsonArray
 )
-


### PR DESCRIPTION
We're using a database named `team4IterationDev`, not `dev`.

(mongoseed.sh and Server.java already use the correct database--it was only mongoseed.bat that was different.)