### PR TITLE
Streamline dependency injection

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -56,7 +56,6 @@ dependencies {
 
   testImplementation 'com.mockrunner:mockrunner-servlet:2.0.1'
 
-  implementation 'javax.inject:javax.inject:1'
   testImplementation 'org.mockito:mockito-core:2.28.2'
 }
 

--- a/server/src/main/java/umm3601/note/DeathTimer.java
+++ b/server/src/main/java/umm3601/note/DeathTimer.java
@@ -6,15 +6,12 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Timer;
 import java.util.TimerTask;
-import javax.inject.Inject;
-import javax.inject.Singleton;
 
 import com.fasterxml.jackson.databind.util.StdDateFormat;
 import com.mongodb.client.MongoDatabase;
 
 
 
-@Singleton
 public class DeathTimer extends Timer {
 
   public final long ONE_WEEK_MILLIS = 604800000; // 1 week, in milliseconds
@@ -24,12 +21,6 @@ public class DeathTimer extends Timer {
 
   private NoteController noteController;
 
-  @Inject
-  void NoteControllerSetup(MongoDatabase db) {
-    noteController = new NoteController(db, this);
-  }
-
-  @Inject
   private static DeathTimer deathTimerInstance = new DeathTimer();
 
   protected DeathTimer() {

--- a/server/src/main/java/umm3601/note/NoteController.java
+++ b/server/src/main/java/umm3601/note/NoteController.java
@@ -10,9 +10,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 
-
-import javax.inject.Inject;
-
 import com.google.common.collect.ImmutableMap;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
@@ -43,13 +40,12 @@ public class NoteController {
 
   JacksonCodecRegistry jacksonCodecRegistry = JacksonCodecRegistry.withDefaultObjectMapper();
 
-  @Inject private final MongoCollection<Note> noteCollection;
+  private final MongoCollection<Note> noteCollection;
 
   /**
    * @param database the database containing the note data
    */
 
-  @Inject
   public NoteController(MongoDatabase database, DeathTimer dt) {
     jacksonCodecRegistry.addCodecForClass(Note.class);
     noteCollection = database.getCollection("notes").withDocumentClass(Note.class)

--- a/server/src/test/java/umm3601/note/NoteControllerSpec.java
+++ b/server/src/test/java/umm3601/note/NoteControllerSpec.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
@@ -64,6 +65,7 @@ public class NoteControllerSpec {
   // I'll be honest this is some real bullshit to make myself able to inject
   // dtMock.
 
+  @InjectMocks
   NoteController noteController;
 
   static ObjectMapper jsonMapper = new ObjectMapper();
@@ -111,8 +113,6 @@ public class NoteControllerSpec {
 
     noteDocuments.insertMany(testNotes);
     noteDocuments.insertOne(Document.parse(sam.toJson()));
-
-    noteController = new NoteController(db, dtMock);
   }
 
   @AfterAll

--- a/server/src/test/java/umm3601/note/NoteControllerSpec.java
+++ b/server/src/test/java/umm3601/note/NoteControllerSpec.java
@@ -36,7 +36,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
@@ -65,7 +64,6 @@ public class NoteControllerSpec {
   // I'll be honest this is some real bullshit to make myself able to inject
   // dtMock.
 
-  @InjectMocks
   NoteController noteController;
 
   static ObjectMapper jsonMapper = new ObjectMapper();

--- a/server/src/test/java/umm3601/note/TimerTasksSpec.java
+++ b/server/src/test/java/umm3601/note/TimerTasksSpec.java
@@ -21,7 +21,7 @@ public class TimerTasksSpec {
   @Mock(name = "noteController") NoteController mockNoteController;
 
   @InjectMocks
-   DeathTimer deathTimer;
+  DeathTimer deathTimer;
 
   private static ObjectId samsNoteId;
 


### PR DESCRIPTION
This pull request removes the dependency on the javax.inject package, along with all of the annotations it provides. These annotations provide hooks for a dependency injection tool, but since we're not using such a tool, they're just lying dormant at the moment 😢

Along the way, it also removes a line in NoteControllerSpec where we explicitly initialize a NoteController object—Mockito's `@InjectMocks` annotation will already create that object for us automagically 🙂