### PR TITLE
Fix a bug with deleting notes

### DIFF
--- a/server/src/main/java/umm3601/note/NoteController.java
+++ b/server/src/main/java/umm3601/note/NoteController.java
@@ -74,7 +74,7 @@ public class NoteController {
     }
     if (note == null) {
       throw new NotFoundResponse("The requested note was not found.");
-    } else if (note.ownerID != ownerID) {
+    } else if (!note.ownerID.equals(ownerID)) {
       throw new NotFoundResponse("The requested note does not belong to this owner.");
     } else {
       ctx.json(note);


### PR DESCRIPTION
Previously, we had been using `==` rather than `.equals()` to compare strings. As a result, the test for "are you the owner of this note" was always evaluating to false.

`.equals()` compares the content of two strings, while `==` checks that two strings are stored in the same location in memory, which isn't what we wanted to check for.

This pull request changes the `==` to `.equals()`, which should allow people to delete notes.