### PR TITLE
Make a NewNote interface

### DIFF
--- a/client/src/app/notes/add-note.component.ts
+++ b/client/src/app/notes/add-note.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, Input, SystemJsNgModuleLoader} from '@angular/core';
 import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { Router } from '@angular/router';
-import { Note } from './note';
+import { NewNote } from './note';
 import { NoteService } from './note.service';
 import { Owner } from '../owner/owner';
 
@@ -18,7 +18,6 @@ export class AddNoteComponent implements OnInit {
   @Input() owner_id: string;
 
   addNoteForm: FormGroup;
-  note: Note;
   constructor(private fb: FormBuilder,
               private noteService: NoteService, private snackBar: MatSnackBar, private router: Router, ) {
   }
@@ -63,10 +62,9 @@ export class AddNoteComponent implements OnInit {
 
 
   submitForm() {
-    const noteToAdd: Note = this.addNoteForm.value;
+    const noteToAdd: NewNote = this.addNoteForm.value;
     //const owner_id = this.router.url.substring(9); // trim off "/notes/new/"
     noteToAdd.ownerID = this.owner_id;
-    noteToAdd.addDate = new Date().toISOString();
     this.noteService.addNewNote(noteToAdd).subscribe(newID => {
 
       this.snackBar.open('Added Note ', null, {

--- a/client/src/app/notes/note.service.ts
+++ b/client/src/app/notes/note.service.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { environment } from '../../environments/environment';
 import { map } from 'rxjs/operators';
-import { Note, NoteStatus } from './note';
+import { Note, NoteStatus, NewNote } from './note';
 
 @Injectable()
 export class NoteService {
@@ -61,7 +61,7 @@ export class NoteService {
     return filteredNotes;
   }
 
-  addNewNote(newNote: Note): Observable<string> {
+  addNewNote(newNote: NewNote): Observable<string> {
     // Send a post request to add a new note with the note data as the body.
     // const test = this.httpClient.post<{id: string}>(this.noteUrl + '/new', newNote).pipe(map(res => res.id));
     return this.httpClient.post<{id: string}>(this.noteUrl + '/new', newNote).pipe(map(res => res.id));

--- a/client/src/app/notes/note.ts
+++ b/client/src/app/notes/note.ts
@@ -1,4 +1,4 @@
-export interface Note {
+export interface Note extends NewNote {
   _id: string;
   ownerID: string;
   body: string;

--- a/client/src/app/notes/note.ts
+++ b/client/src/app/notes/note.ts
@@ -5,7 +5,19 @@ export interface Note {
   addDate: string;
   expireDate: string;
   status: NoteStatus;
-
 }
+
+/**
+ * When we create a new note, not all of the fields exist yet. Some of
+ * them are left for the server to fill in.
+ */
+export interface NewNote {
+  ownerID: string;
+  body: string;
+  addDate: string;
+  expireDate: string;
+  status: NoteStatus;
+}
+
 
 export type NoteStatus = 'active' | 'template' | 'draft' | 'deleted';

--- a/client/src/app/notes/note.ts
+++ b/client/src/app/notes/note.ts
@@ -1,10 +1,5 @@
 export interface Note extends NewNote {
   _id: string;
-  ownerID: string;
-  body: string;
-  addDate: string;
-  expireDate: string;
-  status: NoteStatus;
 }
 
 /**


### PR DESCRIPTION
Newly created notes that we haven't sent to the server yet have only a fraction of the fields that a normal note has. Because of this, it makes sense to have a different class for them.

(In particular, having a different class for them makes Karma testing easier 🙃)

(Previously, we were using just one class for both and using a lot of unsafe casting to make up for it.)