### PR TITLE
Change the "audience" field in the Auth0 setup

### DIFF
--- a/client/src/environments/environment.prod.ts
+++ b/client/src/environments/environment.prod.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: true,
   API_URL: '/api/',
-  OUR_API_NAME: 'https://64.227.25.112.nip.io/api/',
+  OUR_API_NAME: 'https://droptables.csci.app/api/',
 };

--- a/client/src/environments/environment.ts
+++ b/client/src/environments/environment.ts
@@ -5,7 +5,7 @@
 export const environment = {
   production: false,
   API_URL: '/api/',
-  OUR_API_NAME: 'https://64.227.25.112.nip.io/api/',
+  OUR_API_NAME: 'https://droptables.csci.app/api/',
 };
 
 /*


### PR DESCRIPTION
We just got a new domain name, and we registered a newly-named API with Auth0 to match it.

With this commit, the client will ask Auth0 for a token for use by our new API, instead of asking for a token for the old, deleted API.