### PR TITLE
Fix js problems on client

### DIFF
--- a/client/src/app/doorBoard/doorBoard-page.component.ts
+++ b/client/src/app/doorBoard/doorBoard-page.component.ts
@@ -101,14 +101,20 @@ export class DoorBoardPageComponent implements OnInit, OnDestroy {
 
   public getLoginSub(): Observable<string> {
     const currentSub = this.auth.userProfile$.pipe(
-      map(profile => JSON.stringify(profile.sub).replace(/['"]+/g, ''))
+      map(profile => {
+        if (profile) {
+          return JSON.stringify(profile.sub).replace(/['"]+/g, '');
+        } else {
+          return null;
+        }
+      })
     );
     return currentSub;
   }
 
 
   public compareSubs(): Observable<boolean> {
-    return this.getLoginSub().pipe(map(val => val === this.getSub()));
+    return this.getLoginSub().pipe(map(val => val !== null && val === this.getSub()));
   }
 
 


### PR DESCRIPTION
If the user is not logged in, then their Auth0 profile is null, and you can't read their login sub, which is a field of the Auth0 profile.

Previously, we weren't checking if profile is null, and we were getting null-related errors. (Hundreds of them a second.) Now, we're checking for null, and that problem goes away ;)