### PR TITLE
Tiny CSS fix to prevent long notes from outgrowing their cards :)

### DIFF
--- a/client/src/app/doorBoard/doorBoard-page.component.scss
+++ b/client/src/app/doorBoard/doorBoard-page.component.scss
@@ -22,8 +22,6 @@ flex-wrap: wrap;
 }
 
 .note-card {
-  // flex-wrap: wrap;
-  max-block-size: 5rem;
   margin: 0.5rem;
 }
 


### PR DESCRIPTION
Removed line "max-block-size: 5rem" in .note-card