### PR TITLE
Collection of fixes/UI tweaks

### DIFF
--- a/client/e2e/src/doorBoard-list.e2e-spec.ts
+++ b/client/e2e/src/doorBoard-list.e2e-spec.ts
@@ -11,7 +11,7 @@ describe('DoorBoard list', () => {
   });
 
   it('Should have the correct title', () => {
-    expect(page.getDoorBoardTitle()).toEqual('DoorBoards');
+    expect(page.getDoorBoardTitle()).toEqual('Search DoorBoards');
   });
 
   it('Should type something in the name filter and check that it returned correct elements', async () => {

--- a/client/src/app/app.component.scss
+++ b/client/src/app/app.component.scss
@@ -12,7 +12,7 @@
 }
 
 .mat-toolbar.mat-primary {
-  position: fixed;
+  position: sticky;
   top: 0;
   left: 0;
   z-index: 2;

--- a/client/src/app/app.component.scss
+++ b/client/src/app/app.component.scss
@@ -1,10 +1,10 @@
 .sidenav-container {
   height: 100%;
+  margin: -0.3rem;
 }
 
 .sidenav {
   width: 256px;
-
 }
 
 .sidenav .mat-toolbar {
@@ -20,13 +20,14 @@
 }
 
 .app-title {
-  padding-left: 20px;
+  padding-left: 0.7rem;
+  font-size: medium;
 }
 
 
 .app-navbar {
   position:absolute;
-  right: 5%;
+  right: 3.5%;
 }
 
 .main-content {

--- a/client/src/app/app.component.scss
+++ b/client/src/app/app.component.scss
@@ -12,10 +12,11 @@
 }
 
 .mat-toolbar.mat-primary {
-  position: sticky;
+  position: fixed;
   top: 0;
-  z-index: 1;
-
+  left: 0;
+  z-index: 2;
+  width: 100% !important;
 }
 
 .app-title {

--- a/client/src/app/doorBoard/doorBoard-list.component.html
+++ b/client/src/app/doorBoard/doorBoard-list.component.html
@@ -1,11 +1,8 @@
 <div fxLayout="row">
   <div fxFlex fxFlex.gt-sm="80" fxFlexOffset.gt-sm="10">
-    <mat-card class="doorBoard-list-card">
-      This is page is under construction currently! This page will allow access to individual doorBoard page.
-    </mat-card>
     <mat-card class="search-card">
       <mat-card-header>
-        <mat-card-title class="doorBoard-list-title">DoorBoards</mat-card-title>
+        <mat-card-title class="doorBoard-list-title">Search DoorBoards</mat-card-title>
       </mat-card-header>
       <mat-card-content fxLayout="column" >
 

--- a/client/src/app/doorBoard/doorBoard-page.component.html
+++ b/client/src/app/doorBoard/doorBoard-page.component.html
@@ -39,7 +39,7 @@
              </div>
              <mat-card class="note-card" *ngFor="let note of this.filteredNotes">
                <mat-card-content>
-              <p matLine class="note-list-body"> {{note.body}} </p>
+              <p matLine class="note-list-body">{{note.body}}</p>
               <p matLine class="note-list-expiration-date">{{note.expireDate}}</p>
               <p matLine class="note-list-add-date">Created on {{note.addDate | date:'MMM d'}} at {{note.addDate | date:'h:mm aa'}}</p>
             </mat-card-content>

--- a/client/src/app/doorBoard/doorBoard-page.component.html
+++ b/client/src/app/doorBoard/doorBoard-page.component.html
@@ -38,9 +38,11 @@
                 </mat-radio-group>
              </div>
              <mat-card class="note-card" *ngFor="let note of this.filteredNotes">
+               <mat-card-content>
               <p matLine class="note-list-body"> {{note.body}} </p>
               <p matLine class="note-list-expiration-date">{{note.expireDate}}</p>
               <p matLine class="note-list-add-date">Created on {{note.addDate | date:'MMM d'}} at {{note.addDate | date:'h:mm aa'}}</p>
+            </mat-card-content>
             </mat-card>
       </div>
     </div>

--- a/client/src/app/doorBoard/doorBoard-page.component.html
+++ b/client/src/app/doorBoard/doorBoard-page.component.html
@@ -27,8 +27,8 @@
   </div>
 
     <!--Notes-->
+    <div class="grid-container">
     <div fxFlex>
-      <div class="grid-container">
             <div *ngIf="compareSubs() | async">
                 <mat-radio-group  name="radioGroup" [(ngModel)]="noteStatus" (change)="radioChange($event)" id="note-status-select">
                   <mat-radio-button class="radioButton" value="active">Active</mat-radio-button>
@@ -47,13 +47,12 @@
       </div>
     </div>
 
-  <div fxFlex>
+
     <!--google calendar and related-->
     <div class="grid-container">
     <div class="gcal-embed" *ngIf="this.doorBoard">
-      <iframe [src]="this.GcalURL" style="border: 0" width="478" style="border: 0" height="700" frameborder="0"
+      <iframe [src]="this.GcalURL" style="border: 0" width="450" style="border: 0" height="700" frameborder="0"
         scrolling="auto"></iframe>
-    </div>
     </div>
   </div>
 </div>

--- a/client/src/app/doorBoard/doorBoard-page.component.scss
+++ b/client/src/app/doorBoard/doorBoard-page.component.scss
@@ -23,6 +23,7 @@ flex-wrap: wrap;
 
 .note-card {
   margin: 0.5rem;
+  white-space: pre-wrap;
 }
 
 

--- a/client/src/app/doorBoard/doorBoard-page.component.scss
+++ b/client/src/app/doorBoard/doorBoard-page.component.scss
@@ -1,5 +1,7 @@
 .doorBoard-card {
   margin: 3px;
+  text-size-adjust: 0.75rem;
+  line-height: 0.7rem;
 }
 
 .page {
@@ -14,6 +16,12 @@ flex-wrap: wrap;
 .radioButton {
   margin: 0.4rem;
 }
+
+  .gcal-embed iframe {
+    width: max-content;
+    min-width: 30rem;
+    max-width: 60rem;
+  }
 
 
 .grid-container {

--- a/client/src/app/doorBoard/doorBoard-page.component.ts
+++ b/client/src/app/doorBoard/doorBoard-page.component.ts
@@ -101,9 +101,13 @@ export class DoorBoardPageComponent implements OnInit, OnDestroy {
   }
 
   public getSub(): string {
-    // console.log('From ID: ' + this.doorBoard.sub);
+    if (this.doorBoard){
     return this.doorBoard.sub;
+    } else {
+      return null;
+    }
   }
+
 
 
   public getLoginSub(): Observable<string> {
@@ -129,7 +133,7 @@ export class DoorBoardPageComponent implements OnInit, OnDestroy {
     console.log($event.source.name, $event.value);
 
     if ($event.source.name === 'radioGroup') {
-      console.log('Pressed Radio Button!');
+      // console.log('Pressed Radio Button!');
       this.getNotesFromServer();
     }
   }

--- a/client/src/app/doorBoard/doorBoard-page.component.ts
+++ b/client/src/app/doorBoard/doorBoard-page.component.ts
@@ -121,7 +121,7 @@ export class DoorBoardPageComponent implements OnInit, OnDestroy {
 
 
   public compareSubs(): Observable<boolean> {
-    return this.getLoginSub().pipe(map(val => val !== null && val === this.getSub()));
+    return this.getLoginSub().pipe(map(val => val !== null && this.doorBoard !== null && val === this.getSub()));
   }
 
 

--- a/client/src/app/nav-bar/nav-bar.component.scss
+++ b/client/src/app/nav-bar/nav-bar.component.scss
@@ -1,0 +1,6 @@
+.mat-raised-button {
+  font-size: 0.75rem;
+  text-align: center;
+  text-transform: uppercase;
+  text-decoration:none;
+}

--- a/client/src/app/notes/add-note.component.html
+++ b/client/src/app/notes/add-note.component.html
@@ -26,7 +26,7 @@ is potentially helpful and contributed to the shaping of this example -->
 
           <mat-form-field>
             <mat-label>Body</mat-label>
-            <textarea matInput #input id="bodyField" placeholder="Body" formControlName="body" required [cdkTextareaAutosize]></textarea>
+            <textarea matInput id="bodyField" #bodyInput placeholder="Body" formControlName="body" required [cdkTextareaAutosize]></textarea>
           </mat-form-field>
 
         </mat-card-content>

--- a/client/src/app/notes/add-note.component.scss
+++ b/client/src/app/notes/add-note.component.scss
@@ -1,3 +1,3 @@
 .add-note {
-  margin: 5px;
+  margin: 0.3rem;
 }

--- a/client/src/app/notes/add-note.component.ts
+++ b/client/src/app/notes/add-note.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
+import { Component, OnInit, Input, Output, EventEmitter, ViewChild, ElementRef } from '@angular/core';
 import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { Router } from '@angular/router';
@@ -6,7 +6,7 @@ import { NewNote } from './note';
 import { NoteService } from './note.service';
 import { DoorBoardService } from '../doorBoard/doorBoard.service';
 import { DoorBoard } from '../doorBoard/doorBoard';
-import {TextFieldModule} from '@angular/cdk/text-field';
+
 
 
 
@@ -23,6 +23,7 @@ export class AddNoteComponent implements OnInit {
   // enabled = true;
 
   @Input() doorBoard_id: string;
+  @ViewChild('bodyInput') bodyInput: ElementRef;
 
   addNoteForm: FormGroup;
   @Output() newNoteAdded = new EventEmitter();
@@ -79,11 +80,14 @@ export class AddNoteComponent implements OnInit {
 
 
   submitForm() {
+    // Body.value = '';
     const noteToAdd: NewNote = this.addNoteForm.value;
     noteToAdd.doorBoardID = this.doorBoard_id;
     this.noteService.addNewNote(noteToAdd).subscribe(newID => {
       // Notify the DoorBoard component that a note has been added.
       this.newNoteAdded.emit();
+      // Clear input form
+      this.bodyInput.nativeElement.value = '';
       this.snackBar.open('Added Note ', null, {
         duration: 2000,
       });

--- a/client/src/app/notes/edit-note.component.ts
+++ b/client/src/app/notes/edit-note.component.ts
@@ -9,7 +9,7 @@ import { OnInit, Component } from '@angular/core';
 
 export class EditNoteComponent implements OnInit {
   ngOnInit(): void {
-    throw new Error("Method not implemented.");
+    throw new Error('Method not implemented.');
   }
 
   constructor() {}

--- a/client/src/index.html
+++ b/client/src/index.html
@@ -4,7 +4,7 @@
   <app-navbar></app-navbar>
   <router-outlet></router-outlet>
   <meta charset="utf-8">
-  <title>DoorBoard</title>
+  <title class="main">DoorBoard</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">


### PR DESCRIPTION
1. Display new lines in note cards
2. Clear text entry box after submitting notes
3. Position mobile toolbar so it does not end when side-scrolling
4. Adjust fonts/margins/etc for better mobile support
5. End crashing console, thanks to the help of Paul.
6. Allow the getSub function to return nulls (the final blow to the console problems after Paul's help)
7. Use proper <mat-card-content> tags around note content (Paul's suggestion and observation)
8. Remove construction banner from search area